### PR TITLE
Detect short version string for long names.

### DIFF
--- a/tools/Beat_Saber/questmods.html
+++ b/tools/Beat_Saber/questmods.html
@@ -152,6 +152,14 @@
                 }
                 if(firstVisit) localStorage.oldMods = JSON.stringify(existing)
                 AddGameVersions()
+                for (let checkVersion in gameVersions) {
+                    let urlVersion = params.get("version")
+                    if (checkVersion.includes(urlVersion)) {
+                        gameversion.value = checkVersion
+
+                    }
+                   
+                }
                 Display(gameversion.value)
             }
 


### PR DESCRIPTION
Added a function to check if the version query string contains a short url (eg. 1.27.0 or 1.28.0) and automatically switch to that page to allow urls without the complete version string to be matched.