### PR TITLE
Remove pinkcore builds that are for wrong vesion

### DIFF
--- a/tools/Beat_Saber/mods.json
+++ b/tools/Beat_Saber/mods.json
@@ -9631,28 +9631,6 @@
       "modloader": "QuestLoader"
     },
     {
-      "name": "PinkCore",
-      "description": "PinkCore is a core mod that ports over the rest of SongCore\u0027s features.\nThis includes adding information to your game such as Mappers names, Mod Requirements, Custom Colours, Custom Difficulty names, Burn Marks, and more!",
-      "id": "pinkcore",
-      "version": "1.9.0",
-      "download": "https://github.com/ModdingPink/PinkCore/releases/download/v1.9.0/PinkCore.qmod",
-      "source": "https://github.com/ModdingPink/PinkCore/",
-      "author": "RedBrumbler, Pink, StackDoubleFlow, Lillie, darknight1050",
-      "cover": "https://raw.githubusercontent.com/ModdingPink/PinkCore/master/cover.png",
-      "modloader": "Scotland2"
-    },
-    {
-      "name": "PinkCore",
-      "description": "PinkCore is a core mod that ports over the rest of SongCore\u0027s features.\nThis includes adding information to your game such as Mappers names, Mod Requirements, Custom Colours, Custom Difficulty names, Burn Marks, and more!",
-      "id": "pinkcore",
-      "version": "1.9.1",
-      "download": "https://github.com/ModdingPink/PinkCore/releases/download/v1.9.1/PinkCore.qmod",
-      "source": "https://github.com/ModdingPink/PinkCore/",
-      "author": "RedBrumbler, Pink, StackDoubleFlow, Lillie, darknight1050",
-      "cover": "https://raw.githubusercontent.com/ModdingPink/PinkCore/master/cover.png",
-      "modloader": "Scotland2"
-    },
-    {
       "name": "Colorama",
       "description": "Change all the colors!",
       "id": "colorama",


### PR DESCRIPTION
Removes the Pinkcore versions of which RedBrumbler didn't increase the package version for 1.28.0